### PR TITLE
adding warning on missing gtag and callback for once loaded|

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -8,7 +8,7 @@ export default function() {
     return;
   }
 
-  const { config, globalObjectName, enabled } = options;
+  const { config, globalObjectName, enabled, ready } = options;
   const url = `https://www.googletagmanager.com/gtag/js?id=${config.id}`;
 
   loadScript(url)
@@ -28,8 +28,10 @@ export default function() {
       if (options.pageTrackerEnabled) {
         pageTracker();
       }
+
+      ready(window[globalObjectName])
     })
-    .catch(() => {
-      warn("Ops! Something happened and gtag.js couldn't be loaded");
+    .catch((e) => {
+      warn("Ops! Something happened and gtag.js couldn't be loaded", e);
     });
 }

--- a/src/lib/query.js
+++ b/src/lib/query.js
@@ -5,5 +5,10 @@ export default function(method, ...args) {
     return;
   }
 
-  window[options.globalObjectName](method, ...args);
+  if (window[options.globalObjectName]) {
+    window[options.globalObjectName](method, ...args);
+  } else {
+    console.warn("gtag is not loaded yet")
+  }
+
 }


### PR DESCRIPTION
Was having issues with cannot call apply of undefined.  Traced it to the loading of the gtag script, it wasn't present in the window object yet.  Was calling a config to link adwords in the created() lifecycle hook of the App (and then tried a child object too). This solution adds a ready() callback to the config object which is passed the loaded gtag function too.

```js
const analyticsConfig = {
  config: {
    id: 'id-here'
  },
  ready: function(gtag) {
    gtag("config", "your-value-here")
    console.log("Callback Complete")
  }
}
```