### PR TITLE
Fix event() type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,5 @@
     "vue-template-compiler": "^2.6.10",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
-  },
-  "dependencies": {
-    "@types/gtag.js": "0.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "vue-template-compiler": "^2.6.10",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
+  },
+  "dependencies": {
+    "@types/gtag.js": "0.0.3"
   }
 }

--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -8,12 +8,6 @@ declare module 'vue-gtag' {
     page_path: string;
   }
 
-  export interface Event {
-    event_category: string;
-    event_label: string;
-    value: string;
-  }
-
   export interface ScreenView {
     app_name: string;
     screen_name: string;
@@ -38,7 +32,16 @@ declare module 'vue-gtag' {
 
   export interface VueGtag {
     pageview(pageView: PageView): void;
-    event(action: string, event: Event): void;
+
+    /**
+     * Send a Google Analytics Event.
+     *
+     * @see https://developers.google.com/analytics/devguides/collection/gtagjs/events
+     *
+     * @param action string that will appear as the event action in Google Analytics Event reports
+     * @param eventParams
+     */
+    event(action: string, eventParams?: Gtag.ControlParams | Gtag.EventParams | Gtag.CustomParams): void;
     screenview(screenView: ScreenView): void;
     customMap(map: Dictionary<string>): void;
     purchase(purchase: Purchase): void;
@@ -74,7 +77,7 @@ declare module 'vue-gtag' {
 
   module 'vue/types/vue' {
     interface Vue {
-      $ga: VueGtag;
+      $gtag: VueGtag;
     }
   }
 }

--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -8,6 +8,16 @@ declare module 'vue-gtag' {
     page_path: string;
   }
 
+  export interface EventParams {
+    /** string that will appear as the event category */
+    event_category?: string;
+    /** string that will appear as the event label */
+    event_label?: string;
+    /** non-negative integer that will appear as the event value */
+    value?: number;
+    [key: string]: any;
+  }
+
   export interface ScreenView {
     app_name: string;
     screen_name: string;
@@ -41,7 +51,7 @@ declare module 'vue-gtag' {
      * @param action string that will appear as the event action in Google Analytics Event reports
      * @param eventParams
      */
-    event(action: string, eventParams?: Gtag.ControlParams | Gtag.EventParams | Gtag.CustomParams): void;
+    event(action: string, eventParams?: EventParams): void;
     screenview(screenView: ScreenView): void;
     customMap(map: Dictionary<string>): void;
     purchase(purchase: Purchase): void;


### PR DESCRIPTION
Relates to #45, #57

@GerryWilko, thanks for the initial type definitions in https://github.com/MatteoGabriele/vue-gtag/pull/57! This takes a pass at some issues I found with it, mostly focusing on `event()`, which I am familiar with.

Specifically, this improves and make event parameters optional.