### PR TITLE
Fix method name in the Vue interface

### DIFF
--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -74,7 +74,7 @@ declare module 'vue-gtag' {
 
   module 'vue/types/vue' {
     interface Vue {
-      $ga: VueGtag;
+      $gtag: VueGtag;
     }
   }
 }


### PR DESCRIPTION
It was pointing to $ga instead of $gtag