### PR TITLE
Isolate global dataLayer

### DIFF
--- a/__tests__/__snapshots__/install.spec.js.snap
+++ b/__tests__/__snapshots__/install.spec.js.snap
@@ -7,6 +7,7 @@ Object {
   "defaultGroupName": "default",
   "disableScriptLoad": false,
   "enabled": true,
+  "globalDataLayerName": "dataLayer",
   "globalObjectName": "gtag",
   "includes": null,
   "onAfterTrack": [Function],

--- a/__tests__/bootstrap.spec.js
+++ b/__tests__/bootstrap.spec.js
@@ -22,6 +22,7 @@ describe("bootstrap", () => {
 
   it("should load the gtag.js file", done => {
     getOptions.mockReturnValueOnce({
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       config: {
         id: 1
@@ -32,7 +33,7 @@ describe("bootstrap", () => {
 
     flushPromises().then(() => {
       expect(util.loadScript).toHaveBeenCalledWith(
-        "https://www.googletagmanager.com/gtag/js?id=1",
+        "https://www.googletagmanager.com/gtag/js?id=1&l=dataLayer",
         "https://www.googletagmanager.com"
       );
       done();
@@ -42,6 +43,7 @@ describe("bootstrap", () => {
   it("should not load the gtag.js file", () => {
     getOptions.mockReturnValueOnce({
       disableScriptLoad: true,
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       config: {
         id: 1
@@ -57,6 +59,7 @@ describe("bootstrap", () => {
     const spy = jest.fn();
 
     getOptions.mockReturnValueOnce({
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       onReady: spy,
       config: {
@@ -74,6 +77,7 @@ describe("bootstrap", () => {
 
   it("should have dataLayer and gtag defined", done => {
     getOptions.mockReturnValueOnce({
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       config: {
         id: 1
@@ -91,6 +95,7 @@ describe("bootstrap", () => {
 
   it("should opt-out when plugin has `enabled` set to false", done => {
     getOptions.mockReturnValueOnce({
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       enabled: false,
       config: {
@@ -109,6 +114,7 @@ describe("bootstrap", () => {
   it("should load the gtag.js file also when opt-out", done => {
     getOptions.mockReturnValueOnce({
       enabled: false,
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       config: {
         id: 1
@@ -126,6 +132,7 @@ describe("bootstrap", () => {
   it("should have dataLayer and gtag defined also when opt-out", done => {
     getOptions.mockReturnValueOnce({
       enabled: false,
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       config: {
         id: 1
@@ -143,6 +150,7 @@ describe("bootstrap", () => {
 
   it("should inject a custom name for the gtag library", () => {
     getOptions.mockReturnValueOnce({
+      globalDataLayerName: "dataLayer",
       globalObjectName: "foo",
       config: {
         id: 1
@@ -159,6 +167,7 @@ describe("bootstrap", () => {
 
   it("should start tracking pages when enabled", () => {
     getOptions.mockReturnValueOnce({
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       pageTrackerEnabled: true,
       config: {
@@ -175,6 +184,7 @@ describe("bootstrap", () => {
 
   it("should not start tracking pages when enabled", () => {
     getOptions.mockReturnValueOnce({
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       pageTrackerEnabled: false,
       config: {
@@ -194,6 +204,7 @@ describe("bootstrap", () => {
     util.loadScript = jest.fn(() => Promise.reject(new Error()));
 
     getOptions.mockReturnValueOnce({
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       pageTrackerEnabled: true,
       config: {
@@ -214,6 +225,7 @@ describe("bootstrap", () => {
 
   it("should fire all the includes", () => {
     getOptions.mockReturnValueOnce({
+      globalDataLayerName: "dataLayer",
       globalObjectName: "gtag",
       disableScriptLoad: true,
       enabled: true,

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -11,6 +11,7 @@ export default function() {
   const {
     enabled,
     globalObjectName,
+    globalDataLayerName,
     config: { id, params },
     includes,
     pageTrackerEnabled,
@@ -23,9 +24,9 @@ export default function() {
   }
 
   if (window[globalObjectName] == null) {
-    window.dataLayer = window.dataLayer || [];
+    window[globalDataLayerName] = [];
     window[globalObjectName] = function() {
-      window.dataLayer.push(arguments);
+      window[globalDataLayerName].push(arguments);
     };
   }
 
@@ -56,7 +57,7 @@ export default function() {
   }
 
   const domain = "https://www.googletagmanager.com";
-  const resource = `${domain}/gtag/js?id=${id}`;
+  const resource = `${domain}/gtag/js?id=${id}&l=${globalDataLayerName}`;
 
   return loadScript(resource, domain)
     .then(() => {

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -27,7 +27,7 @@ export default function() {
   }
 
   if (window[globalObjectName] == null) {
-    window[globalDataLayerName] = [];
+    window[globalDataLayerName] = window[globalDataLayerName] || [];
     window[globalObjectName] = function() {
       window[globalDataLayerName].push(arguments);
     };

--- a/src/install.js
+++ b/src/install.js
@@ -13,6 +13,7 @@ let options = {
   disableScriptLoad: false,
   bootstrap: true,
   globalObjectName: "gtag",
+  globalDataLayerName: "dataLayer",
   pageTrackerEnabled: true,
   pageTrackerScreenviewEnabled: false,
   defaultGroupName: "default",


### PR DESCRIPTION
Hi there,

There's an issue where window.dataLayer can be used by multiple google tag manager usages within a page. This PR adds the possibility to specify `globalDataLayerName` to achieve isolation.