### PR TITLE
fix(screenview): missing config hit

### DIFF
--- a/__tests__/__snapshots__/install.spec.js.snap
+++ b/__tests__/__snapshots__/install.spec.js.snap
@@ -2,8 +2,14 @@
 
 exports[`install should have default options 1`] = `
 Object {
+  "appName": null,
   "bootstrap": true,
-  "config": null,
+  "config": Object {
+    "id": null,
+    "params": Object {
+      "send_page_view": false,
+    },
+  },
   "customPreconnectOrigin": "https://www.googletagmanager.com",
   "customResourceURL": "https://www.googletagmanager.com/gtag/js",
   "defaultGroupName": "default",

--- a/__tests__/api/pageview.spec.js
+++ b/__tests__/api/pageview.spec.js
@@ -1,17 +1,23 @@
 import pageview from "@/api/pageview";
-import config from "@/api/config";
+import event from "@/api/event";
 
-jest.mock("@/api/config");
+jest.mock("@/api/event");
 
 describe("api/pageview", () => {
   it("should be called with this parameters", () => {
     pageview("foo");
-    expect(config).toHaveBeenCalledWith({
+
+    expect(event).toHaveBeenCalledWith("page_view", {
       page_path: "foo",
       page_location: "http://localhost/",
+      send_page_view: true,
     });
 
     pageview({ foo: "bar" });
-    expect(config).toHaveBeenCalledWith({ foo: "bar" });
+
+    expect(event).toHaveBeenCalledWith("page_view", {
+      foo: "bar",
+      send_page_view: true,
+    });
   });
 });

--- a/__tests__/api/screenview.spec.js
+++ b/__tests__/api/screenview.spec.js
@@ -1,14 +1,35 @@
+import { getOptions } from "@/install";
 import screenview from "@/api/screenview";
 import event from "@/api/event";
 
 jest.mock("@/api/event");
+jest.mock("@/install");
 
 describe("api/screenview", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should be called with this parameters", () => {
-    screenview("foo");
-    expect(event).toHaveBeenCalledWith("screen_view", "foo");
+    getOptions.mockReturnValue({
+      config: { id: 1 },
+      appName: "MyApp",
+    });
+
+    screenview("bar");
+
+    expect(event).toHaveBeenCalledWith("screen_view", {
+      send_page_view: true,
+      screen_name: "bar",
+      app_name: "MyApp",
+    });
 
     screenview({ foo: "bar" });
-    expect(event).toHaveBeenCalledWith("screen_view", { foo: "bar" });
+
+    expect(event).toHaveBeenCalledWith("screen_view", {
+      send_page_view: true,
+      foo: "bar",
+      app_name: "MyApp",
+    });
   });
 });

--- a/__tests__/util.spec.js
+++ b/__tests__/util.spec.js
@@ -59,15 +59,15 @@ describe("mergeDeep", () => {
 
 describe("warn", () => {
   it("should warn with a customized message prefix", () => {
-    console.warn = jest.fn();
+    console.error = jest.fn();
     util.warn("foo");
-    expect(console.warn).toHaveBeenCalledWith("[vue-gtag] foo");
+    expect(console.error).toHaveBeenCalledWith("[vue-gtag] foo");
   });
 
   it("should console the error", () => {
-    console.warn = jest.fn();
+    console.error = jest.fn();
     util.warn("foo", new Error());
-    expect(console.warn).toHaveBeenCalledTimes(2);
+    expect(console.error).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/api/pageview.js
+++ b/src/api/pageview.js
@@ -1,4 +1,4 @@
-import config from "./config";
+import event from "./event";
 
 export default (...args) => {
   const [arg] = args;
@@ -13,5 +13,9 @@ export default (...args) => {
     params = arg;
   }
 
-  config(params);
+  if (params.send_page_view == null) {
+    params.send_page_view = true;
+  }
+
+  event("page_view", params);
 };

--- a/src/api/screenview.js
+++ b/src/api/screenview.js
@@ -1,5 +1,26 @@
+import { getOptions } from "../install";
 import event from "./event";
 
 export default (...args) => {
-  event("screen_view", ...args);
+  const { appName } = getOptions();
+  const [arg] = args;
+  let params = {};
+
+  if (typeof arg === "string") {
+    params = {
+      screen_name: arg,
+    };
+  } else {
+    params = arg;
+  }
+
+  if (params.app_name == null) {
+    params.app_name = appName;
+  }
+
+  if (params.send_page_view == null) {
+    params.send_page_view = true;
+  }
+
+  event("screen_view", params);
 };

--- a/src/install.js
+++ b/src/install.js
@@ -22,7 +22,13 @@ export let options = {
   pageTrackerSkipSamePath: true,
   defaultGroupName: "default",
   includes: null,
-  config: null,
+  appName: null,
+  config: {
+    id: null,
+    params: {
+      send_page_view: false,
+    },
+  },
 };
 
 export const getOptions = () => options;

--- a/src/page-tracker.js
+++ b/src/page-tracker.js
@@ -1,5 +1,6 @@
 import { getVue, getRouter, getOptions } from "./install";
 import { warn } from "./util";
+import api from "./api";
 import pageview from "./api/pageview";
 import screenview from "./api/screenview";
 
@@ -71,7 +72,8 @@ export const startRouter = (Router) => {
   /* istanbul ignore next */
   Router.onReady((current) => {
     Vue.nextTick().then(() => {
-      trackPage({ to: current, params: config.params });
+      api.config(config.params);
+      trackPage({ to: current });
     });
 
     Router.afterEach((to, from) => {

--- a/src/util.js
+++ b/src/util.js
@@ -26,10 +26,10 @@ export function loadScript(url, preconnectOrigin) {
 }
 
 export function warn(msg, err) {
-  console.warn("[vue-gtag] " + msg);
+  console.error("[vue-gtag] " + msg);
 
   if (err && err.stack) {
-    console.warn(err.stack);
+    console.error(err.stack);
   }
 }
 


### PR DESCRIPTION
- add missing config hit with screenview events
- use events instead of config for pageviews and screenviews
- add default send_page_view to false and add send_page_view to true for every pageview and screenview hit because the documentation suggests this on SPAs