### PR TITLE
fix(vue-gtag.d.ts): fix for typescript types & deduping utils.js

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prettier.vueIndentScriptAndStyle": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "prettier.vueIndentScriptAndStyle": true
-}

--- a/src/add-routes-tracker.js
+++ b/src/add-routes-tracker.js
@@ -1,5 +1,5 @@
 import { nextTick } from "vue";
-import { isFn } from "@/utils";
+import { isFunction } from "@vue/shared";
 import { getRouter } from "@/router";
 import { getOptions } from "@/options";
 import addConfiguration from "@/add-configuration";
@@ -33,13 +33,13 @@ export default () => {
           return;
         }
 
-        if (isFn(onBeforeTrack)) {
+        if (isFunction(onBeforeTrack)) {
           onBeforeTrack(to, from);
         }
 
         track(to, from);
 
-        if (isFn(onAfterTrack)) {
+        if (isFunction(onAfterTrack)) {
           onAfterTrack(to, from);
         }
       });

--- a/src/track.js
+++ b/src/track.js
@@ -1,5 +1,6 @@
+import { isFunction } from "@vue/shared";
 import { getOptions } from "@/options";
-import { validateScreenviewShape, isFn } from "@/utils";
+import { validateScreenviewShape } from "@/utils";
 import * as api from "@/api";
 
 export default (to = {}, from = {}) => {
@@ -16,7 +17,7 @@ export default (to = {}, from = {}) => {
 
   let template = to;
 
-  if (isFn(proxy)) {
+  if (isFunction(proxy)) {
     template = proxy(to, from);
   } else if (useScreenview) {
     template = validateScreenviewShape({

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import { isPlainObject } from "@vue/shared";
+
 export const load = (url, options = {}) => {
   return new Promise((resolve, reject) => {
     if (typeof document === "undefined") {
@@ -27,12 +29,6 @@ export const load = (url, options = {}) => {
   });
 };
 
-export const isFn = (fn) => typeof fn === "function";
-
-export const isObject = (item) => {
-  return item && typeof item === "object" && !Array.isArray(item);
-};
-
 export const mergeDeep = (target, ...sources) => {
   if (!sources.length) {
     return target;
@@ -40,12 +36,12 @@ export const mergeDeep = (target, ...sources) => {
 
   const source = sources.shift();
 
-  if (!isObject(target) || !isObject(source)) {
+  if (!isPlainObject(target) || !isPlainObject(source)) {
     return;
   }
 
   for (const key in source) {
-    if (isObject(source[key])) {
+    if (isPlainObject(source[key])) {
       if (!target[key]) {
         Object.assign(target, { [key]: {} });
       }

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -74,23 +74,3 @@ describe("warn", () => {
     expect(console.warn).toHaveBeenCalledWith("[vue-gtag] foo");
   });
 });
-
-describe("isFn", () => {
-  it("should return true", () => {
-    expect(util.isFn(() => {})).toBe(true);
-  });
-
-  it("should return false", () => {
-    expect(util.isFn("hello")).toBe(false);
-  });
-});
-
-describe("isObject", () => {
-  it("should return true", () => {
-    expect(util.isObject({})).toBe(true);
-  });
-  it("should return false", () => {
-    expect(util.isObject([])).toBe(false);
-    expect(util.isObject("aa")).toBe(false);
-  });
-});

--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -1,6 +1,6 @@
 declare module "vue-gtag" {
-  import VueRouter from "vue-router";
-  import _Vue from "vue";
+  import type { App } from "vue";
+  import type { Router } from "vue-router";
 
   /**
    * Types copied from @types/gtag.js.
@@ -12,7 +12,7 @@ declare module "vue-gtag" {
       (command: 'config', targetId: string, config?: ControlParams | EventParams | CustomParams): void;
       (command: 'set', config: CustomParams): void;
       (command: 'js', config: Date): void;
-      (command: 'event', eventName: EventNames | string, eventParams?: ControlParams |  EventParams | CustomParams): void;
+      (command: 'event', eventName: EventNames | string, eventParams?: ControlParams | EventParams | CustomParams): void;
     }
 
     interface CustomParams {
@@ -284,9 +284,9 @@ declare module "vue-gtag" {
 
   export class VueGtagPlugin {
     static install(
-      Vue: typeof _Vue,
+      app: App,
       options: PluginOptions,
-      router?: VueRouter
+      router?: Router
     ): void;
   }
 


### PR DESCRIPTION
- Fix for issue #314 (In Vue 3.x plugin installations now use the application instance as the first parameter - not Vue).
- Removing functions `isObject` and `isFn` and replacing with exported utility functions available in Vue 3.x (`@vue/shared`). The exported functions now used are `isPlainObject` and `isFunction` - I just recently found out about these. To see what other utility functions check the [vue-next shared package source code](https://github.com/vuejs/vue-next/tree/master/packages/shared/src).