### PR TITLE
feat(typescript): add Vue global property

### DIFF
--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -313,5 +313,9 @@ declare module "vue-gtag" {
     interface Vue {
       $gtag: VueGtag;
     }
+
+    interface VueConstructor {
+      $gtag: VueGtag;
+    }
   }
 }


### PR DESCRIPTION
I use this plugin on Nuxt2.
refer to
https://github.com/nuxt-community/google-analytics-module/issues/111#issuecomment-880592964
So, I use this plugin **version1**.

But, this line appears TypeError.
```ts
inject('gtag', Vue.$gtag)
// Property '$gtag' does not exist on type 'VueConstructor<Vue>'
```

This line looks that we can access `Vue.$gtag`, and I can actually access it.
https://github.com/MatteoGabriele/vue-gtag/blob/25db88c7b1f86d8328e7c1e6576e7c41cbd47657/src/attach-api.js#L3

So, I added a type definition