### PR TITLE
fixed linker parameter

### DIFF
--- a/src/api/linker.js
+++ b/src/api/linker.js
@@ -1,5 +1,5 @@
 import config from "./config";
 
 export default (params) => {
-  config("linker", params);
+  config({ linker: params });
 };

--- a/test/api/linker.spec.js
+++ b/test/api/linker.spec.js
@@ -7,8 +7,10 @@ describe("linker", () => {
   test("fires a linker config", () => {
     linker({ foo: "bar" });
 
-    expect(config).toHaveBeenCalledWith("linker", {
-      foo: "bar",
+    expect(config).toHaveBeenCalledWith({
+      linker: {
+        foo: "bar",
+      },
     });
   });
 });


### PR DESCRIPTION
I got an error below when I tried to use gtag's cross-domain functionality with this plugin.

![screenshot](https://user-images.githubusercontent.com/145686/133207344-02969c41-1f35-459f-bad9-ea5bdd5148b7.png)

According to the official gtag document, it seems to be a matter of parameter format.

https://developers.google.com/analytics/devguides/collection/gtagjs/cross-domain#automatically_link_domains

It should be:

```javascript
query("config", "GA_MEASUREMENT_ID", { linker: { domains: [...]  }});
```

not:

```javascript
query("config", "GA_MEASUREMENT_ID", "linker", { domains: [...]  });
```