### PR TITLE
updated readme link to vue-gtag docs to point to v2 instead of v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install vue-gtag@next
 
 ## Documentation
 
-- [vue-gtag documentation](https://matteo-gabriele.gitbook.io/vue-gtag/)
+- [vue-gtag documentation](https://matteo-gabriele.gitbook.io/vue-gtag/v/v2.0.0/)
 - [gtag.js official documentation](https://developers.google.com/analytics/devguides/collection/gtagjs)
 
 ## Issues and features requests


### PR DESCRIPTION
Tried out vue-gtag for first time and confusion reigned because I didn't realize that the docs that I linked to from the readme were v1 not v2. 

I ended up spending lots of time troubleshooting different versions, incompatibilities and type issues - all resolved once I realized I was following the outdated docs. Works great now!