### PR TITLE
Allow tracking UTM parameters properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,6 @@
     "vue-template-compiler": "^2.6.10"
   },
   "dependencies": {
-    "utm-synapse": "^1.2.0"
+    "utm-synapse": "^1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -108,5 +108,8 @@
     "vue": "^2.6.12",
     "vue-router": "^3.1.3",
     "vue-template-compiler": "^2.6.10"
+  },
+  "dependencies": {
+    "utm-synapse": "^1.2.0"
   }
 }

--- a/src/api/pageview.js
+++ b/src/api/pageview.js
@@ -1,3 +1,5 @@
+import { utmSynapse } from "utm-synapse";
+
 import { getOptions } from "@/options";
 import { getRouter } from "@/router";
 import { getPathWithBase, isBrowser } from "@/utils";
@@ -10,15 +12,17 @@ export default (param) => {
 
   let template;
 
+  const {
+    pageTrackerUseFullPath: useFullPath,
+    pageTrackerPrependBase: useBase,
+    trackInitialUtmParams: trackInitialUtmParams,
+  } = getOptions();
+
   if (typeof param === "string") {
     template = {
       page_path: param,
     };
   } else if (param.path || param.fullPath) {
-    const {
-      pageTrackerUseFullPath: useFullPath,
-      pageTrackerPrependBase: useBase,
-    } = getOptions();
     const router = getRouter();
     const base = router && router.options.base;
     const path = useFullPath ? param.fullPath : param.path;
@@ -29,6 +33,18 @@ export default (param) => {
     };
   } else {
     template = param;
+  }
+
+  if (trackInitialUtmParams) {
+    const utmParams = utmSynapse.load();
+
+    if (utmParams) {
+      template.page_location = utmSynapse.setIntoUrl(
+        window.location.href,
+        utmParams
+      );
+      utmSynapse.clear();
+    }
   }
 
   if (template.page_location == null) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import { utmSynapse } from "utm-synapse";
+
 import attachApi from "@/attach-api";
 import { setOptions, getOptions } from "@/options";
 import bootstrap from "@/bootstrap";
@@ -7,6 +9,18 @@ const install = (Vue, options = {}, router) => {
   attachApi(Vue);
   setOptions(options);
   setRouter(router);
+
+  if (getOptions().trackInitialUtmParams) {
+    const utmParams = utmSynapse.parse();
+
+    if (utmParams) {
+      utmSynapse.save(utmParams);
+    }
+  }
+
+  if (getOptions().hideInitialUtmParams) {
+    utmSynapse.cleanDisplayedUrl();
+  }
 
   if (getOptions().bootstrap) {
     bootstrap();

--- a/src/options.js
+++ b/src/options.js
@@ -14,6 +14,8 @@ export const getDefaultParams = () => ({
   pageTrackerEnabled: true,
   enabled: true,
   disableScriptLoad: false,
+  trackInitialUtmParams: false,
+  hideInitialUtmParams: false,
   pageTrackerScreenviewEnabled: false,
   appName: null,
   pageTrackerUseFullPath: false,

--- a/test/__snapshots__/options.spec.js.snap
+++ b/test/__snapshots__/options.spec.js.snap
@@ -18,6 +18,7 @@ Object {
   "enabled": true,
   "globalDataLayerName": "dataLayer",
   "globalObjectName": "gtag",
+  "hideInitialUtmParams": false,
   "includes": null,
   "onAfterTrack": null,
   "onBeforeTrack": null,
@@ -30,6 +31,7 @@ Object {
   "pageTrackerSkipSamePath": true,
   "pageTrackerTemplate": null,
   "pageTrackerUseFullPath": false,
+  "trackInitialUtmParams": false,
 }
 `;
 
@@ -51,6 +53,7 @@ Object {
   "enabled": true,
   "globalDataLayerName": "dataLayer",
   "globalObjectName": "gtag",
+  "hideInitialUtmParams": false,
   "includes": null,
   "onAfterTrack": null,
   "onBeforeTrack": null,
@@ -63,5 +66,6 @@ Object {
   "pageTrackerSkipSamePath": true,
   "pageTrackerTemplate": null,
   "pageTrackerUseFullPath": false,
+  "trackInitialUtmParams": false,
 }
 `;

--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -274,6 +274,8 @@ declare module "vue-gtag" {
     enabled?: boolean;
     disableScriptLoad?: boolean;
     bootstrap?: boolean;
+    trackInitialUtmParams?: boolean;
+    hideInitialUtmParams?: boolean;
     globalObjectName?: string;
     pageTrackerEnabled?: boolean;
     pageTrackerScreenviewEnabled?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10636,10 +10636,10 @@ util.promisify@~1.0.0:
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
 
-utm-synapse@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/utm-synapse/-/utm-synapse-1.2.0.tgz#167321b87598dae72da4b3bfd14630242fb6c123"
-  integrity sha512-/LVDs1S1kOWLFbMEBaG1LDSpEoJh87iX+JmSUObNZwc2eblbCpKvGoYWX+Elod9BQuFqkcUGMqlc+zDJn3yKcA==
+utm-synapse@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/utm-synapse/-/utm-synapse-1.2.1.tgz#15672acbaf005714154b3a77652efa45873041c2"
+  integrity sha512-dgbL45O16R71EXKecIgqyE+oSPl0ZpDhpNd04qAeQ+LsRx85U85ebxTeQUe3Fcgwyp2QZXjvmK0v3FWypldu/A==
   dependencies:
     memorystorage "^0.12.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,6 +7101,11 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
+memorystorage@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/memorystorage/-/memorystorage-0.12.0.tgz#582a3374d298e8352dc4512df0186c335d137018"
+  integrity sha512-8oAVcjcyCCqG2iYSXf7AhyESaHkodE3UUouMS6NhqoY2Bnb1xoPe3sdbf3ExufPGkFYi/HgP7SPer8SFsc6MYg==
+
 meow@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
@@ -10630,6 +10635,13 @@ util.promisify@~1.0.0:
     es-abstract "^1.17.2"
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
+
+utm-synapse@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/utm-synapse/-/utm-synapse-1.2.0.tgz#167321b87598dae72da4b3bfd14630242fb6c123"
+  integrity sha512-/LVDs1S1kOWLFbMEBaG1LDSpEoJh87iX+JmSUObNZwc2eblbCpKvGoYWX+Elod9BQuFqkcUGMqlc+zDJn3yKcA==
+  dependencies:
+    memorystorage "^0.12.0"
 
 uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"


### PR DESCRIPTION
Hi,

There are multiple reasons the frontend can loose UTM parameters on a SPA frontend (redirection at init, user accepting tracking X minutes after...). So I decided to create a new library to gather those basic methods in response to https://github.com/MatteoGabriele/vue-gtag/issues/351 and https://github.com/MatteoGabriele/vue-gtag/issues/405#issuecomment-1122515015 (and other issues for other frameworks/plugins).

Everything can be read at https://github.com/sneko/utm-synapse

This PR makes this repo now having a dependency (sorry)... but I felt it better to use a new package for this since it could be reused by others in their project (none-Vue but also none-gtag projects).

To use it the just enable the features inside the config:
```
    appName: 'hello',
    trackInitialUtmParams: true,
    hideInitialUtmParams: true,
```

_Since PRs stack up (I can understand it's hard to maintain the library on your spare time) I copied all your deployment logic so my modified package is released and available through `yarn add @sneko/vue-gtag@v1.17.2`(see https://github.com/sneko/vue-gtag/tree/v1.17.2)_

Hope it can help!