### PR TITLE
fix(typings): add missing arguments in PluginOptions functions

### DIFF
--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -1,6 +1,6 @@
 declare module "vue-gtag" {
   import type { App } from "vue";
-  import type { Router } from "vue-router";
+  import type { Router, RouteLocationNormalized } from "vue-router";
 
   /**
    * Types copied from @types/gtag.js.
@@ -267,10 +267,10 @@ declare module "vue-gtag" {
 
   export interface PluginOptions {
     appName?: string;
-    pageTrackerTemplate?: () => PageView;
-    onBeforeTrack?: () => void;
-    onAfterTrack?: () => void;
-    onReady?: () => void;
+    pageTrackerTemplate?: (to: RouteLocationNormalized, from: RouteLocationNormalized) => PageView;
+    onBeforeTrack?: (to: RouteLocationNormalized, from: RouteLocationNormalized) => void;
+    onAfterTrack?: (to: RouteLocationNormalized, from: RouteLocationNormalized) => void;
+    onReady?: (gtag: Gtag.Gtag) => void;
     enabled?: boolean;
     disableScriptLoad?: boolean;
     bootstrap?: boolean;

--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -268,8 +268,8 @@ declare module "vue-gtag" {
   export interface PluginOptions {
     appName?: string;
     pageTrackerTemplate?: (to: RouteLocationNormalized, from: RouteLocationNormalized) => PageView;
-    onBeforeTrack?: (to: RouteLocationNormalized, from: RouteLocationNormalized) => void;
-    onAfterTrack?: (to: RouteLocationNormalized, from: RouteLocationNormalized) => void;
+    onBeforeTrack?: (to: RouteLocationNormalized, from?: RouteLocationNormalized) => void;
+    onAfterTrack?: (to: RouteLocationNormalized, from?: RouteLocationNormalized) => void;
     onReady?: (gtag: Gtag.Gtag) => void;
     enabled?: boolean;
     disableScriptLoad?: boolean;


### PR DESCRIPTION
Hi,

The arguments of the following functions were missing in the typings:
- pageTrackerTemplate
- onBeforeTrack
- onAfterTrack
- onReady