### PR TITLE
feat(route tracker): call hooks on landing page

### DIFF
--- a/src/add-routes-tracker.js
+++ b/src/add-routes-tracker.js
@@ -20,29 +20,27 @@ export default () => {
 
       addConfiguration();
 
-      if (isRouteExcluded(currentRoute.value)) {
-        return;
-      }
-
-      track(currentRoute.value);
+      trackRoute(currentRoute.value);
     });
 
     router.afterEach((to, from) => {
-      nextTick().then(() => {
-        if (isRouteExcluded(to)) {
-          return;
-        }
-
-        if (isFunction(onBeforeTrack)) {
-          onBeforeTrack(to, from);
-        }
-
-        track(to, from);
-
-        if (isFunction(onAfterTrack)) {
-          onAfterTrack(to, from);
-        }
-      });
+      nextTick().then(() => trackRoute(to, from));
     });
   });
+
+  function trackRoute(to, from) {
+    if (isRouteExcluded(to)) {
+      return;
+    }
+
+    if (isFunction(onBeforeTrack)) {
+      onBeforeTrack(to, from);
+    }
+
+    track(to, from);
+
+    if (isFunction(onAfterTrack)) {
+      onAfterTrack(to, from);
+    }
+  }
 };

--- a/test/add-routes-tracker.spec.js
+++ b/test/add-routes-tracker.spec.js
@@ -212,19 +212,14 @@ describe("page-tracker", () => {
   async function testHook(hookName) {
     const app = createApp();
     const hookSpy = jest.fn();
+    const options = {
+      [hookName]: hookSpy,
+      config: { id: 1 },
+    };
 
     app.use(router);
 
-    app.use(
-      VueGtag,
-      {
-        [hookName]: hookSpy,
-        config: {
-          id: 1,
-        },
-      },
-      router
-    );
+    app.use(VueGtag, options, router);
 
     router.push("/");
     await flushPromises();
@@ -234,23 +229,14 @@ describe("page-tracker", () => {
 
     expect(hookSpy).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({
-        path: "/",
-        name: "home",
-      }),
+      expect.objectContaining({ path: "/", name: "home" }),
       undefined
     );
 
     expect(hookSpy).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({
-        path: "/about",
-        name: "about",
-      }),
-      expect.objectContaining({
-        path: "/",
-        name: "home",
-      })
+      expect.objectContaining({ path: "/about", name: "about" }),
+      expect.objectContaining({ path: "/", name: "home" })
     );
 
     expect(hookSpy).toHaveBeenCalledTimes(2);

--- a/test/add-routes-tracker.spec.js
+++ b/test/add-routes-tracker.spec.js
@@ -91,7 +91,7 @@ describe("page-tracker", () => {
 
     expect(addConfiguration).toHaveBeenCalled();
 
-    expect(track).toHaveBeenCalledWith(router.currentRoute.value);
+    expect(track).toHaveBeenCalledWith(router.currentRoute.value, undefined);
     expect(track).toHaveBeenCalledTimes(1);
   });
 
@@ -124,7 +124,8 @@ describe("page-tracker", () => {
       expect.objectContaining({
         path: "/",
         name: "home",
-      })
+      }),
+      undefined
     );
 
     expect(track).toHaveBeenNthCalledWith(
@@ -177,7 +178,17 @@ describe("page-tracker", () => {
     router.push("/about");
     await flushPromises();
 
-    expect(onBeforeTrackSpy).toHaveBeenCalledWith(
+    expect(onBeforeTrackSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: "/",
+        name: "home",
+      }),
+      undefined
+    );
+
+    expect(onBeforeTrackSpy).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         path: "/about",
         name: "about",
@@ -188,7 +199,7 @@ describe("page-tracker", () => {
       })
     );
 
-    expect(onBeforeTrackSpy).toHaveBeenCalledTimes(1);
+    expect(onBeforeTrackSpy).toHaveBeenCalledTimes(2);
   });
 
   test("fires the onAfterTrack method", async () => {
@@ -214,7 +225,17 @@ describe("page-tracker", () => {
     router.push("/about");
     await flushPromises();
 
-    expect(onAfterTrackSpy).toHaveBeenCalledWith(
+    expect(onAfterTrackSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: "/",
+        name: "home",
+      }),
+      undefined
+    );
+
+    expect(onAfterTrackSpy).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         path: "/about",
         name: "about",
@@ -225,7 +246,7 @@ describe("page-tracker", () => {
       })
     );
 
-    expect(onAfterTrackSpy).toHaveBeenCalledTimes(1);
+    expect(onAfterTrackSpy).toHaveBeenCalledTimes(2);
   });
 
   test("remove routes from tracking based on path", async () => {
@@ -267,7 +288,8 @@ describe("page-tracker", () => {
       1,
       expect.objectContaining({
         path: "/",
-      })
+      }),
+      undefined
     );
 
     expect(track).toHaveBeenCalledTimes(1);

--- a/test/add-routes-tracker.spec.js
+++ b/test/add-routes-tracker.spec.js
@@ -156,97 +156,11 @@ describe("page-tracker", () => {
   });
 
   test("fires the onBeforeTrack method", async () => {
-    const app = createApp();
-    const onBeforeTrackSpy = jest.fn();
-
-    app.use(router);
-
-    app.use(
-      VueGtag,
-      {
-        onBeforeTrack: onBeforeTrackSpy,
-        config: {
-          id: 1,
-        },
-      },
-      router
-    );
-
-    router.push("/");
-    await flushPromises();
-
-    router.push("/about");
-    await flushPromises();
-
-    expect(onBeforeTrackSpy).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        path: "/",
-        name: "home",
-      }),
-      undefined
-    );
-
-    expect(onBeforeTrackSpy).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        path: "/about",
-        name: "about",
-      }),
-      expect.objectContaining({
-        path: "/",
-        name: "home",
-      })
-    );
-
-    expect(onBeforeTrackSpy).toHaveBeenCalledTimes(2);
+    await testHook("onBeforeTrack");
   });
 
   test("fires the onAfterTrack method", async () => {
-    const app = createApp();
-    const onAfterTrackSpy = jest.fn();
-
-    app.use(router);
-
-    app.use(
-      VueGtag,
-      {
-        onAfterTrack: onAfterTrackSpy,
-        config: {
-          id: 1,
-        },
-      },
-      router
-    );
-
-    router.push("/");
-    await flushPromises();
-
-    router.push("/about");
-    await flushPromises();
-
-    expect(onAfterTrackSpy).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        path: "/",
-        name: "home",
-      }),
-      undefined
-    );
-
-    expect(onAfterTrackSpy).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        path: "/about",
-        name: "about",
-      }),
-      expect.objectContaining({
-        path: "/",
-        name: "home",
-      })
-    );
-
-    expect(onAfterTrackSpy).toHaveBeenCalledTimes(2);
+    await testHook("onAfterTrack");
   });
 
   test("remove routes from tracking based on path", async () => {
@@ -294,4 +208,51 @@ describe("page-tracker", () => {
 
     expect(track).toHaveBeenCalledTimes(1);
   });
+
+  async function testHook(hookName) {
+    const app = createApp();
+    const hookSpy = jest.fn();
+
+    app.use(router);
+
+    app.use(
+      VueGtag,
+      {
+        [hookName]: hookSpy,
+        config: {
+          id: 1,
+        },
+      },
+      router
+    );
+
+    router.push("/");
+    await flushPromises();
+
+    router.push("/about");
+    await flushPromises();
+
+    expect(hookSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: "/",
+        name: "home",
+      }),
+      undefined
+    );
+
+    expect(hookSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        path: "/about",
+        name: "about",
+      }),
+      expect.objectContaining({
+        path: "/",
+        name: "home",
+      })
+    );
+
+    expect(hookSpy).toHaveBeenCalledTimes(2);
+  }
 });


### PR DESCRIPTION
Hi,

The hooks `onBeforeTrack()`and `onAfterTrack()` were not called on the very first track, when the router is ready, which could be problematic.
This PR makes sure these hooks are called whenever the track function is called.