### PR TITLE
fix: add missing dependency @vue/shared

### DIFF
--- a/src/add-routes-tracker.js
+++ b/src/add-routes-tracker.js
@@ -1,5 +1,5 @@
 import { nextTick } from "vue";
-import { isFunction } from "@vue/shared";
+import { isFn } from "@/utils";
 import { getRouter } from "@/router";
 import { getOptions } from "@/options";
 import addConfiguration from "@/add-configuration";
@@ -33,13 +33,13 @@ export default () => {
           return;
         }
 
-        if (isFunction(onBeforeTrack)) {
+        if (isFn(onBeforeTrack)) {
           onBeforeTrack(to, from);
         }
 
         track(to, from);
 
-        if (isFunction(onAfterTrack)) {
+        if (isFn(onAfterTrack)) {
           onAfterTrack(to, from);
         }
       });

--- a/src/track.js
+++ b/src/track.js
@@ -1,6 +1,5 @@
-import { isFunction } from "@vue/shared";
 import { getOptions } from "@/options";
-import { validateScreenviewShape } from "@/utils";
+import { validateScreenviewShape, isFn } from "@/utils";
 import * as api from "@/api";
 
 export default (to = {}, from = {}) => {
@@ -17,7 +16,7 @@ export default (to = {}, from = {}) => {
 
   let template = to;
 
-  if (isFunction(proxy)) {
+  if (isFn(proxy)) {
     template = proxy(to, from);
   } else if (useScreenview) {
     template = validateScreenviewShape({

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,3 @@
-import { isPlainObject } from "@vue/shared";
-
 export const load = (url, options = {}) => {
   return new Promise((resolve, reject) => {
     if (typeof document === "undefined") {
@@ -29,6 +27,12 @@ export const load = (url, options = {}) => {
   });
 };
 
+export const isFn = (fn) => typeof fn === "function";
+
+export const isObject = (item) => {
+  return item && typeof item === "object" && !Array.isArray(item);
+};
+
 export const mergeDeep = (target, ...sources) => {
   if (!sources.length) {
     return target;
@@ -36,12 +40,12 @@ export const mergeDeep = (target, ...sources) => {
 
   const source = sources.shift();
 
-  if (!isPlainObject(target) || !isPlainObject(source)) {
+  if (!isObject(target) || !isObject(source)) {
     return;
   }
 
   for (const key in source) {
-    if (isPlainObject(source[key])) {
+    if (isObject(source[key])) {
       if (!target[key]) {
         Object.assign(target, { [key]: {} });
       }

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -74,3 +74,23 @@ describe("warn", () => {
     expect(console.warn).toHaveBeenCalledWith("[vue-gtag] foo");
   });
 });
+
+describe("isFn", () => {
+  it("should return true", () => {
+    expect(util.isFn(() => {})).toBe(true);
+  });
+
+  it("should return false", () => {
+    expect(util.isFn("hello")).toBe(false);
+  });
+});
+
+describe("isObject", () => {
+  it("should return true", () => {
+    expect(util.isObject({})).toBe(true);
+  });
+  it("should return false", () => {
+    expect(util.isObject([])).toBe(false);
+    expect(util.isObject("aa")).toBe(false);
+  });
+});


### PR DESCRIPTION
In `/src/add-routes-tracker.js` there's an import from `@vue/shared`, which is not listed in the dependencies. This happens to work in many cases, since the dependency is used by many other vue-packages. But not reliably.

In our project we were unlucky enough to not have `@vue/shared` in the top-level node-modules after running `npm prune --omit=dev`, we only had it nested under other packages (since they didn't share the same version). This caused a `MODULE_NOT_FOUND` exception from node when we tried to load `vue-gtag`. Funnily enough it only happened in production - since the devs never pruned their packages.

I checked if there were any other missing dependencies, but could not find any. `npx depcheck` agrees that this is the only missing dependency.

Another possible solution is to remove the import and just define `const isFunction = (val) => val is Function` on your own.