### PR TITLE
onBeforeTrack handler returning false cancels tracking

### DIFF
--- a/src/add-routes-tracker.js
+++ b/src/add-routes-tracker.js
@@ -34,7 +34,9 @@ export default () => {
         }
 
         if (isFunction(onBeforeTrack)) {
-          onBeforeTrack(to, from);
+          if (onBeforeTrack(to, from) === false) {
+            return;
+          }
         }
 
         track(to, from);

--- a/test/add-routes-tracker.spec.js
+++ b/test/add-routes-tracker.spec.js
@@ -191,6 +191,35 @@ describe("page-tracker", () => {
     expect(onBeforeTrackSpy).toHaveBeenCalledTimes(1);
   });
 
+  test("onBeforeTrack cancels tracking", async () => {
+    const app = createApp();
+    const onBeforeTrackSpy = jest.fn().mockReturnValue(false);
+    const onAfterTrackSpy = jest.fn();
+
+    app.use(router);
+
+    app.use(
+      VueGtag,
+      {
+        onBeforeTrack: onBeforeTrackSpy,
+        onAfterTrack: onAfterTrackSpy,
+        config: {
+          id: 1,
+        },
+      },
+      router
+    );
+
+    router.push("/");
+    await flushPromises();
+
+    router.push("/about");
+    await flushPromises();
+
+    expect(onBeforeTrackSpy).toHaveBeenCalledTimes(1);
+    expect(onAfterTrackSpy).toHaveBeenCalledTimes(0);
+  });
+
   test("fires the onAfterTrack method", async () => {
     const app = createApp();
     const onAfterTrackSpy = jest.fn();

--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -1,6 +1,6 @@
 declare module "vue-gtag" {
   import type { App } from "vue";
-  import type { Router } from "vue-router";
+  import type { Router, RouteLocationNormalized } from "vue-router";
 
   /**
    * Types copied from @types/gtag.js.
@@ -268,8 +268,8 @@ declare module "vue-gtag" {
   export interface PluginOptions {
     appName?: string;
     pageTrackerTemplate?: () => PageView;
-    onBeforeTrack?: () => void;
-    onAfterTrack?: () => void;
+    onBeforeTrack?: (to: RouteLocationNormalized, from: RouteLocationNormalized) => void | boolean;
+    onAfterTrack?: (to: RouteLocationNormalized, from: RouteLocationNormalized) => void;
     onReady?: () => void;
     enabled?: boolean;
     customResourceURL: string;


### PR DESCRIPTION
`pageTrackerExcludedRoutes` array is insufficient for large lists of routes. A custom logic is needed to be able to filter out the pages with no tracking, e.g.:

    app.use(
      VueGtag,
      {
        id: measurementId,
        onBeforeTrack: to => !to.meta?.hidden,
      },
      router,
    )

