### PR TITLE
Update vue-gtag.d.ts

### DIFF
--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -131,12 +131,15 @@ declare module "vue-gtag" {
     /** Checkout option (i.e. selected payment method) */
     checkout_option?: string;
   }
+
+  type UppercaseLetter = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z';
+  export type ISO4217Currency = `${UppercaseLetter}${UppercaseLetter}${UppercaseLetter}`;
   
   export interface EcommerceActionWithCurrency extends EcommerceActionBase {
     /** Value (i.e., revenue) associated with the event */
     value: number;
     /** The currency of the value */
-    currency: string;
+    currency: ISO4217Currency;
   }
   
   export interface EcommerceActionWithoutCurrency extends EcommerceActionBase {

--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -115,19 +115,15 @@ declare module "vue-gtag" {
   /**
    * @see https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#action_data
    */
-  export interface EcommerceAction {
+  export interface EcommerceActionBase {
     /** Unique ID for the transaction. */
     transaction_id: string;
     /** The store or affiliation from which this transaction occurred */
     affiliation?: string;
-    /** Value (i.e., revenue) associated with the event */
-    value?: number;
     /** Tax amount */
     tax?: number;
     /** Shipping cost */
     shipping?: number;
-    /** The currency of the value */
-    currency?: string;
     /** The array containing the associated products */
     items?: Gtag.Item[];
     /** The step (a number) in the checkout process */
@@ -135,6 +131,22 @@ declare module "vue-gtag" {
     /** Checkout option (i.e. selected payment method) */
     checkout_option?: string;
   }
+  
+  export interface EcommerceActionWithCurrency extends EcommerceActionBase {
+    /** Value (i.e., revenue) associated with the event */
+    value: number;
+    /** The currency of the value */
+    currency: string;
+  }
+  
+  export interface EcommerceActionWithoutCurrency extends EcommerceActionBase {
+    /** Value (i.e., revenue) associated with the event */
+    value?: undefined;
+    /** The currency of the value */
+    currency?: undefined;
+  }
+  
+  export type EcommerceAction = EcommerceActionWithCurrency | EcommerceActionWithoutCurrency;
 
   export interface Linker {
     domains: string[];

--- a/vue-gtag.d.ts
+++ b/vue-gtag.d.ts
@@ -126,6 +126,8 @@ declare module "vue-gtag" {
     tax?: number;
     /** Shipping cost */
     shipping?: number;
+    /** The currency of the value */
+    currency?: string;
     /** The array containing the associated products */
     items?: Gtag.Item[];
     /** The step (a number) in the checkout process */


### PR DESCRIPTION
Adds currency to EcommerceAction see https://github.com/MatteoGabriele/vue-gtag/issues/566#issuecomment-2341721556

No further changes required.

```
var purchase = (function (params) {
  event("purchase", params);
});
```

^ looks like it will pass the currency as needed, and from there Google will know what to do with it.