### PR TITLE
fix: vue-gtag.esm.js missing in dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "biome check",
     "test": "vitest",
     "test:once": "vitest run",
-    "prepublishOnly": "yarn lint && yarn test:once && yarn build"
+    "prepublishOnly": "npm run lint && npm run test:once && npm run build"
   },
   "keywords": [
     "google",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "vuejs"
   ],
   "main": "./dist/vue-gtag.cjs.js",
-  "module": "./dist/vue-gtag.es.js",
+  "module": "./dist/vue-gtag.esm.js",
   "unpkg": "./dist/vue-gtag.umd.js",
   "jsdelivr": "./dist/vue-gtag.umd.js",
   "types": "vue-gtag.d.ts",

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, "./src/index.js"),
       name: "VueGtag",
-      formats: ["umd", "es", "cjs"],
+      formats: ["umd", "esm", "cjs"],
       fileName: (format) => `vue-gtag.${format}.js`,
     },
     rollupOptions: {


### PR DESCRIPTION
When switching from Bili to Vite, I overlooked the bundled file format name. Bili used "esm" by default, while Vite uses "es", which caused several bugs.

closes #604
closes #605 
closes #606 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Revised build scripts to use npm commands for consistency.
  - Standardized the module output naming convention for improved clarity.
  - Aligned the library bundling format with the updated ECMAScript module designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->