### PR TITLE
feat: add tree-shakable install method

### DIFF
--- a/example/install.js
+++ b/example/install.js
@@ -1,0 +1,6 @@
+import { configure } from '../dist/vue-gtag'
+
+// Minimal install
+configure({
+  tagid: '123456789'
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "terser": "^5.39.0",
         "vite": "^6.1.0",
         "vite-plugin-dts": "^4.5.0",
+        "vite-plugin-real-import": "0.1.0",
         "vitest": "^3.0.5",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0"
@@ -10261,6 +10262,16 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-real-import": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-real-import/-/vite-plugin-real-import-0.1.0.tgz",
+      "integrity": "sha512-m1h0bwI2bRqkdJhDTvbqdcLmMKusMzFbz1txTHFF24DftqhyQksdjQdvG5G2AtGg8pyzYCKd0eUP+IDl8pPV6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kolorist": "^1.8.0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "vue",
     "vuejs"
   ],
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/vue-gtag.d.ts",
@@ -46,7 +47,9 @@
   "main": "./dist/vue-gtag.js",
   "module": "./dist/vue-gtag.js",
   "types": "./dist/vue-gtag.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "bugs": {
     "url": "https://github.com/MatteoGabriele/vue-gtag/issues"
   },
@@ -69,6 +72,7 @@
     "terser": "^5.39.0",
     "vite": "^6.1.0",
     "vite-plugin-dts": "^4.5.0",
+    "vite-plugin-real-import": "0.1.0",
     "vitest": "^3.0.5",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"

--- a/src/core/create-gtag/create-gtag.ts
+++ b/src/core/create-gtag/create-gtag.ts
@@ -7,6 +7,25 @@ import {
 } from "@/core/settings";
 import type { App } from "vue";
 
+function initGtag() {
+  const { initMode } = getSettings();
+
+  if (initMode === "manual") {
+    return;
+  }
+
+  addGtag();
+}
+
+/**
+ * Configures Google Analytics gtag instance
+ * @param settings - Configuration settings for the gtag plugin
+ */
+export function configure(settings: PluginSettings): void {
+  updateSettings(settings);
+  initGtag();
+}
+
 type GtagAPI = typeof api;
 
 declare module "vue" {
@@ -17,20 +36,12 @@ declare module "vue" {
 
 type CreateGtagReturn = (app: App) => void;
 
-function handleGtag() {
-  const { initMode } = getSettings();
-
-  if (initMode === "manual") {
-    return;
-  }
-
-  addGtag();
-}
-
-/** Creates and initializes the `gtag` function for use within a Vue application. */
+/**
+ * Creates and configures Google Analytics gtag instance for Vue application
+ * @param settings - Configuration settings for the gtag plugin
+ */
 export function createGtag(settings: PluginSettings): CreateGtagReturn {
-  updateSettings(settings);
-  handleGtag();
+  configure(settings);
 
   return (app: App) => {
     app.config.globalProperties.$gtag = api;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,6 +6,7 @@ describe("index", () => {
       {
         "addGtag": [Function],
         "config": [Function],
+        "configure": [Function],
         "consent": [Function],
         "consentDeniedAll": [Function],
         "consentGrantedAll": [Function],

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 import dts from "vite-plugin-dts";
+import realImport from 'vite-plugin-real-import'
 
 export default defineConfig({
   resolve: {
@@ -17,6 +18,7 @@ export default defineConfig({
       fileName: "vue-gtag",
     },
     rollupOptions: {
+      treeshake: true,
       external: ["vue", "vue-router"],
       output: {
         exports: "named",
@@ -32,6 +34,7 @@ export default defineConfig({
       insertTypesEntry: true,
       rollupTypes: true,
     }),
+    realImport('./example/install.js')
   ],
   test: {
     environment: "jsdom",


### PR DESCRIPTION
Adds a tree-shakable install method without global properties. The minimal bundle size of the plugin goes from 2.20kb to 1.80kb
