### PR TITLE
fix(use-consent): does not remove cookie after refresh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,14 @@ jobs:
       - install-deps
       - run: pnpm run check
 
+  typecheck:
+    docker:
+      - image: cimg/node:lts
+    steps:
+      - checkout
+      - install-deps
+      - run: pnpm run typecheck
+        
   build:
     docker:
       - image: cimg/node:lts
@@ -71,6 +79,9 @@ workflows:
       - check:
           requires:
             - lint
+      - typecheck:
+          requires:
+            - check
       - build:
           requires:
             - check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ workflows:
             - check
       - build:
           requires:
-            - check
+            - typecheck
       - test:
           requires:
             - build

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "check": "biome check",
     "fix": "biome check --write",
     "lint": "biome lint",
+    "typecheck": "tsc --noEmit",
     "build": "tsdown",
     "test": "vitest",
     "test:cov": "vitest run --coverage",
     "test:once": "vitest run",
-    "validate": "pnpm check && pnpm lint && pnpm test:once && pnpm build",
+    "validate": "pnpm typecheck && pnpm check && pnpm lint && pnpm test:once && pnpm build",
     "prepublishOnly": "pnpm validate"
   },
   "keywords": [

--- a/src/composables/use-consent.ts
+++ b/src/composables/use-consent.ts
@@ -28,9 +28,9 @@ export function useConsent(): UseWithConsentReturn {
     window.location.reload();
   };
 
-  const rejectAll = () => {
+  const rejectAll = async () => {
     consentDeniedAll("update");
-    removeCookies(GA_COOKIE_VALUE);
+    await removeCookies(GA_COOKIE_VALUE);
     window.location.reload();
   };
 

--- a/src/tests/composables/use-consent.test.ts
+++ b/src/tests/composables/use-consent.test.ts
@@ -52,14 +52,17 @@ describe("useConsent", () => {
     expect(addGtag).toHaveBeenCalled();
   });
 
-  it("should reject all", () => {
+  it("should reject all", async () => {
     const { rejectAll } = useConsent();
 
     rejectAll();
 
     expect(consentDeniedAll).toHaveBeenCalledWith("update");
-    expect(window.location.reload).toHaveBeenCalled();
     expect(removeCookies).toHaveBeenCalledWith("_ga");
+
+    await flushPromises();
+
+    expect(window.location.reload).toHaveBeenCalled();
     expect(addGtag).not.toHaveBeenCalled();
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -146,7 +146,7 @@ export function getPathWithBase(path: string, base: string): string {
 
 const COOKIE_EXPIRED = "expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
 
-export function removeCookies(name: string): void {
+export async function removeCookies(name: string): Promise<void> {
   for (const gaCookie of document.cookie.split(";")) {
     const cookieName = gaCookie.split("=")[0].trim();
 


### PR DESCRIPTION
Defer the reload using the async/await, which pushes the reload to the next tick. 
The deletion itself is synchronous, but this brief delay should give the browser a chance to apply the changes before navigating away.

closes #626 