### PR TITLE
fix(docs): update gtag.js documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Global Site Tag plugin for Vue
 
-The global site tag (gtag.js) is a JavaScript tagging framework and API that allows you to send event data to Google Analytics, Google Ads, and Google Marketing Platform. For general gtag.js [documentation](https://developers.google.com/analytics/devguides/collection/gtagjs), read the gtag.js developer guide.
+The global site tag (gtag.js) is a JavaScript tagging framework and API that allows you to send event data to Google Analytics, Google Ads, and Google Marketing Platform. For general gtag.js [documentation](https://developers.google.com/tag-platform/gtagjs), read the gtag.js developer guide.
 
 ## Requirements
 
@@ -34,7 +34,7 @@ npm install vue-gtag
 ## Documentation
 
 - [vue-gtag documentation](https://matteo-gabriele.gitbook.io/vue-gtag/)
-- [gtag.js official documentation](https://developers.google.com/analytics/devguides/collection/gtagjs)
+- [gtag.js official documentation](https://developers.google.com/tag-platform/gtagjs)
 
 ## Issues and features requests
 


### PR DESCRIPTION
Updates url for google gtag.js docs in readme.  Needs updating on website as well.