### PR TITLE
fix(exports): add node to package.json export conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "exports": {
     ".": {
       "types": "./dist/vue-gtag.d.ts",
-      "import": "./dist/vue-gtag.js"
+      "import": "./dist/vue-gtag.js",
+      "node": "./dist/vue-gtag.js"
     }
   },
   "main": "./dist/vue-gtag.js",


### PR DESCRIPTION
Adds a node condition to the exports in package.json, this resolves issues with eslint-plugin-imports (see https://github.com/MatteoGabriele/vue-gtag/issues/622)