### PR TITLE
refactor(deps): allow optional vue-router 4 and 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "homepage": "https://github.com/MatteoGabriele/vue-gtag#readme",
   "peerDependencies": {
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0 || ^5.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
@@ -74,7 +74,7 @@
     "typescript": "^5.8.3",
     "vitest": "^3.0.5",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "vue-router": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
         specifier: ^3.5.13
         version: 3.5.14(typescript@5.8.3)
       vue-router:
-        specifier: ^4.5.0
+        specifier: ^4.5.0 || ^5.0.0
         version: 4.5.1(vue@3.5.14(typescript@5.8.3))
 
 packages:

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from 'tsdown'
-import { name } from './package.json'
+import pkg from './package.json' with { type: 'json' }
 
 export default defineConfig({
   entry: {
-    [name]: './src/index.ts'
+    [pkg.name]: './src/index.ts'
   },
   platform: 'browser',
   minify: true,


### PR DESCRIPTION
Adds optional Vue Router v4 and v5 since [v5 has no breaking changes](https://router.vuejs.org/guide/migration/v4-to-v5)

closes #640 